### PR TITLE
Add student scoop feature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ noArg {
 dependencies {
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.0'
-    implementation 'ch.qos.logback:logback-classic:1.5.12'
+    implementation 'ch.qos.logback:logback-classic:1.5.13'
     implementation 'org.slf4j:slf4j-api:2.0.16'
     implementation 'org.reflections:reflections:0.10.2'
     implementation "net.dv8tion:JDA:5.0.0-beta.24"
@@ -28,6 +28,9 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:2.0.20"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0"
     implementation("club.minnced:jda-ktx:0.12.0")
+    implementation 'org.jsoup:jsoup:1.17.2'
+    implementation "io.ktor:ktor-client-core:3.2.3"
+    implementation "io.ktor:ktor-client-cio:3.2.3"
 }
 
 

--- a/src/main/kotlin/command/SetScoopChannel.kt
+++ b/src/main/kotlin/command/SetScoopChannel.kt
@@ -59,7 +59,7 @@ class SetScoopChannel(private val jda: JDA) : Command() {
         var guilds: List<Guild>? = null
         runSQLUntilMaxTries { guilds = guildDao?.queryBuilder()?.where()?.ne("scoopChannelId", 0)?.query()}
         val guildsJDA: ArrayList<net.dv8tion.jda.api.entities.Guild> = ArrayList()
-        for (guild in jda.guilds) {
+        for (guild in guilds!!) {
             val guildJDA = jda.getGuildById(guild.id)
             if (guildJDA != null) {
                 guildsJDA.add(guildJDA)

--- a/src/main/kotlin/command/SetScoopChannel.kt
+++ b/src/main/kotlin/command/SetScoopChannel.kt
@@ -1,0 +1,149 @@
+package tech.trip_kun.sinon.command
+
+import com.j256.ormlite.dao.Dao
+import dev.minn.jda.ktx.coroutines.await
+import io.ktor.client.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
+import org.jsoup.Jsoup
+import tech.trip_kun.sinon.Logger
+import tech.trip_kun.sinon.data.entity.Guild
+import tech.trip_kun.sinon.data.entity.ScoopEntry
+import tech.trip_kun.sinon.data.getGuildDao
+import tech.trip_kun.sinon.data.getScoopEntryDao
+import tech.trip_kun.sinon.data.runSQLUntilMaxTries
+import tech.trip_kun.sinon.exception.CommandExitException
+import tech.trip_kun.sinon.getDispatcher
+private val ktorClient = HttpClient(CIO)
+private val scoopCoroutineScope = CoroutineScope(getDispatcher())
+class SetScoopChannel(private val jda: JDA) : Command() {
+    init {
+        val name = "setscoopchannel"
+        val description = "Set the Student Scoop channel (not including a channel will disable Student Scoop posting)."
+        addArgument(Argument(name, description, true, ArgumentType.COMMAND, null))
+        addArgument(
+            Argument(
+                "channel",
+                "The channel to set as the scoop channel.",
+                false,
+                ArgumentType.CHANNEL,
+                null
+            )
+        )
+        initialize(jda)
+        scoopCoroutineScope.launch {
+            while (true) {
+                try {
+                    handleScoops()
+                } catch (e: Exception) {
+                    Logger.error("Reminder handling failed: ${e.message}")
+                }
+                kotlinx.coroutines.delay(1000 * 60 * 60) // Runs once an hour
+            }
+        }
+    }
+    private suspend fun handleScoops() {
+        var scoopEntryDao: Dao<ScoopEntry, Long>? = null
+        var guildDao: Dao<Guild, Long>? = null
+        runSQLUntilMaxTries { scoopEntryDao = getScoopEntryDao() }
+        runSQLUntilMaxTries { guildDao = getGuildDao() }
+        var guilds: List<Guild>? = null
+        runSQLUntilMaxTries { guilds = guildDao?.queryBuilder()?.where()?.ne("scoopChannelId", 0)?.query()}
+        val guildsJDA: ArrayList<net.dv8tion.jda.api.entities.Guild> = ArrayList()
+        for (guild in jda.guilds) {
+            val guildJDA = jda.getGuildById(guild.id)
+            if (guildJDA != null) {
+                guildsJDA.add(guildJDA)
+            }
+        }
+        val listDoc = Jsoup.parse(ktorClient.get("https://blogs.mtu.edu/stu-org-news/category/todays-issue/").bodyAsText())
+        val docLink = listDoc.select("h2.entry-title").first()?.getElementsByTag("a")?.first()?.attr("abs:href")
+        if (docLink == null) {
+            Logger.error("Something went wrong finding the student scoop link")
+            return
+        }
+        val doc = Jsoup.parse(ktorClient.get(docLink).bodyAsText())
+        val importantPics = doc.select("a[href].fancybox")
+        importantPics.forEach {
+            val link = it.attr("abs:href")
+            var scoopEntries: List<ScoopEntry>? = null
+            runSQLUntilMaxTries { scoopEntries = scoopEntryDao?.queryBuilder()?.where()?.eq("messageLink", link)?.query() }
+            guilds?.forEach {it2 ->
+                if (scoopEntries?.none { e -> e.guild.id == it2.id } == true) {
+                    val embedBuilder = EmbedBuilder()
+                    embedBuilder.setTitle("Student Scoop")
+                    embedBuilder.setImage(link)
+                    val channel = guildsJDA.find { g->g.idLong == it2.id }?.getTextChannelById(it2.scoopChannelId)
+                    val message = channel?.sendMessageEmbeds(embedBuilder.build())?.await()
+                    if (message!=null) {
+                        val newEntry = ScoopEntry(it2, message.idLong, channel.idLong, link)
+                        runSQLUntilMaxTries { scoopEntryDao?.create(newEntry) }
+                    }
+                }
+            }
+        }
+
+
+    }
+    override fun getCategory(): CommandCategory {
+        return CommandCategory.UTILITY
+    }
+
+    override suspend fun handler(event: MessageReceivedEvent) {
+        requireGuild(event)
+        requireUserPermission(event, Permission.MANAGE_SERVER)
+        val arguments = parseArguments(event)
+        if (arguments.isEmpty()) {
+            event.channel.sendMessageEmbeds(commonWork(event.guild, null).build()).await()
+        } else {
+            val channel = arguments[0].getLongValue()?.let { event.guild.getTextChannelById(it) }
+            event.channel.sendMessageEmbeds(commonWork(event.guild, channel).build()).await()
+        }
+    }
+
+    override suspend fun handler(event: SlashCommandInteractionEvent) {
+        requireGuild(event)
+        requireUserPermission(event, Permission.MANAGE_SERVER)
+        val arguments = parseArguments(event)
+        if (arguments.isEmpty()) {
+            event.channel.sendMessageEmbeds(commonWork(event.guild, null).build()).await()
+        } else {
+            val channel = arguments[0].getLongValue()?.let { event.guild?.getTextChannelById(it) }
+            event.channel.sendMessageEmbeds(commonWork(event.guild, channel).build()).await()
+        }
+    }
+    private suspend fun commonWork(guildJDA: net.dv8tion.jda.api.entities.Guild?, channel: TextChannel?): EmbedBuilder {
+        var guildDao: Dao<Guild, Long>? = null
+        runSQLUntilMaxTries {
+            guildDao = getGuildDao()
+        }
+        val embed = EmbedBuilder()
+        embed.setTitle("Student Scoop Channel")
+        runSQLUntilMaxTries {
+            if (guildJDA ==null) {
+                throw CommandExitException("Guild not found") // This won't happen because of the requireGuild check but makes kotlin shut up
+            }
+            var guild = guildDao?.queryForId(guildJDA.idLong)
+            if (guild == null) {
+                guild = Guild(guildJDA.idLong)
+            }
+            guild.scoopChannelId = channel?.idLong ?: 0
+            guildDao?.createOrUpdate(guild)
+        }
+        if (channel == null) {
+            embed.setDescription("Scoop channel disabled")
+        } else {
+            embed.setDescription("Scoop channel set to ${channel.asMention}")
+        }
+        return embed
+    }
+}

--- a/src/main/kotlin/data/DatabaseUtils.kt
+++ b/src/main/kotlin/data/DatabaseUtils.kt
@@ -251,7 +251,19 @@ private fun upgrade(startVersion: Int, endVersion: Int) {
                 // There are no modifications to the database schema between version 1 and version 2, just additions of new tables
             }
             2 -> {
-                // Just new tables.
+                // Add scoopChannelId column to guilds (default 0, non-null)
+                try {
+                    databaseInfoDao.executeRawNoArgs(
+                        "ALTER TABLE guilds ADD COLUMN scoopChannelId BIGINT NOT NULL DEFAULT 0"
+                    )
+                } catch (e: SQLException) {
+                    // Ignore if the column already exists
+                    if (!e.message.orEmpty().contains("Duplicate column name", ignoreCase = true)) {
+                        addEmergencyNotification(EmergencyNotification("Migration Error", 10, e.stackTraceToString()))
+                        throw e
+                    }
+                }
+                // scoop_entries table is created by TableUtils below via entity annotations.
             }
             3 -> {
                 // Not yet implemented

--- a/src/main/kotlin/data/DatabaseUtils.kt
+++ b/src/main/kotlin/data/DatabaseUtils.kt
@@ -19,8 +19,9 @@ private var reminderDao: Dao<Reminder, Long>? = null
 private var banEntryDao: Dao<BanEntry, Int>? = null
 private var guildDao: Dao<Guild, Long>? = null
 private var starboardEntryDao: Dao<StarboardEntry, Long>? = null
+private var scoopEntryDao: Dao<ScoopEntry, Long>? = null
 private lateinit var databaseInfoDao: Dao<DatabaseInfo, Int>
-private val DATABASE_VERSION = 2
+private val DATABASE_VERSION = 3
 
 //Complete
 //Need to make a try-3-times method to use for all database calls
@@ -31,6 +32,7 @@ private val DATABASE_VERSION = 2
 // This is to ensure that the bot can still function without the database
 private var databaseEnabled = false
 val config = getConfig()
+@OptIn(ExperimentalCoroutinesApi::class)
 val globalDispatcher = newSingleThreadContext("GlobalDispatcher")
 
 class DatabaseException(message: String) : RuntimeException(message) {
@@ -164,6 +166,10 @@ private fun loadDatabase() {
         val starboardEntryDao2: Dao<StarboardEntry, Long> = DaoManager.createDao(connectionSource, StarboardEntry::class.java)
         starboardEntryDao2.setObjectCache(true)
         starboardEntryDao = starboardEntryDao2
+        TableUtils.createTableIfNotExists(connectionSource, ScoopEntry::class.java)
+        val scoopEntryDao2: Dao<ScoopEntry, Long> = DaoManager.createDao(connectionSource, ScoopEntry::class.java)
+        scoopEntryDao2.setObjectCache(true)
+        scoopEntryDao = scoopEntryDao2
         databaseEnabled = true
         dbTries = 0
     } catch (e: SQLException) {
@@ -228,6 +234,15 @@ fun getStarboardEntryDao(): Dao<StarboardEntry, Long> {
     }
     return starboardEntryDao!!
 }
+fun getScoopEntryDao(): Dao<ScoopEntry, Long> {
+    if (!databaseEnabled && !databaseDoNotTryAgain) {
+        runSQLUntilMaxTries { loadDatabase() }
+    }
+    if (scoopEntryDao == null) {
+        throw DatabaseException("ScoopEntry DAO is null")
+    }
+    return scoopEntryDao!!
+}
 private fun upgrade(startVersion: Int, endVersion: Int) {
     if (startVersion < endVersion) {
         when (startVersion) {
@@ -236,7 +251,10 @@ private fun upgrade(startVersion: Int, endVersion: Int) {
                 // There are no modifications to the database schema between version 1 and version 2, just additions of new tables
             }
             2 -> {
-                // Next upgrade, not yet implemented
+                // Just new tables.
+            }
+            3 -> {
+                // Not yet implemented
             }
         }
         upgrade(startVersion + 1, endVersion)
@@ -244,7 +262,7 @@ private fun upgrade(startVersion: Int, endVersion: Int) {
 }
 
 
-private suspend fun reloadDatabase() {
+private suspend fun reloadDatabase()  {
     if (databaseDoNotTryAgain || dbTries >= config.databaseSettings.databaseMaxRetries) {
         return
     }

--- a/src/main/kotlin/data/DatabaseUtils.kt
+++ b/src/main/kotlin/data/DatabaseUtils.kt
@@ -334,6 +334,9 @@ private fun closeDatabase() {
         userDao = null
         reminderDao = null
         banEntryDao = null
+        guildDao = null
+        starboardEntryDao = null
+        scoopEntryDao = null
         databaseDoNotTryAgain = true
         databaseEnabled = false
         dbTries = config.databaseSettings.databaseMaxRetries + 1

--- a/src/main/kotlin/data/entity/Guild.kt
+++ b/src/main/kotlin/data/entity/Guild.kt
@@ -1,5 +1,6 @@
 package tech.trip_kun.sinon.data.entity
 
+import com.j256.ormlite.field.DataType
 import com.j256.ormlite.field.DatabaseField
 import com.j256.ormlite.field.ForeignCollectionField
 import com.j256.ormlite.table.DatabaseTable
@@ -43,8 +44,8 @@ class StarboardEntry(
 @ReflectionNoArg
 @DatabaseTable(tableName = "scoop_entries")
 class ScoopEntry(
-    @DatabaseField(foreign = true, canBeNull = false) var guild: Guild,
+    @DatabaseField(foreign = true, canBeNull = false, uniqueCombo=true, index=true) var guild: Guild,
     @DatabaseField(canBeNull = false, id = true) var messageId: Long,
     @DatabaseField(canBeNull = false) var channelId: Long,
-    @DatabaseField(canBeNull = false) var messageLink: String
+    @DatabaseField(canBeNull = false, uniqueCombo=true, dataType = DataType.LONG_STRING) var messageLink: String
 )

--- a/src/main/kotlin/data/entity/Guild.kt
+++ b/src/main/kotlin/data/entity/Guild.kt
@@ -15,10 +15,16 @@ class Guild(@DatabaseField(id = true) var id: Long) {
     var starboardChannelId: Long = 0
 
     @DatabaseField(canBeNull = false)
+    var scoopChannelId: Long = 0
+
+    @DatabaseField(canBeNull = false)
     var starboardLimit: Int = 3 // Default to 3 stars needed to go to starboard
 
     @ForeignCollectionField(eager = true)
     var starboardEntries: Collection<StarboardEntry> = mutableListOf()
+
+    @ForeignCollectionField(eager = true)
+    var scoopEntries: Collection<ScoopEntry> = mutableListOf()
 }
 
 
@@ -34,3 +40,11 @@ class StarboardEntry(
     var starboardMessageId: Long = 0 // The corresponding message in the starboard
 
 }
+@ReflectionNoArg
+@DatabaseTable(tableName = "scoop_entries")
+class ScoopEntry(
+    @DatabaseField(foreign = true, canBeNull = false) var guild: Guild,
+    @DatabaseField(canBeNull = false, id = true) var messageId: Long,
+    @DatabaseField(canBeNull = false) var channelId: Long,
+    @DatabaseField(canBeNull = false) var messageLink: String
+)

--- a/src/main/kotlin/data/entity/Guild.kt
+++ b/src/main/kotlin/data/entity/Guild.kt
@@ -44,8 +44,8 @@ class StarboardEntry(
 @ReflectionNoArg
 @DatabaseTable(tableName = "scoop_entries")
 class ScoopEntry(
-    @DatabaseField(foreign = true, canBeNull = false, uniqueCombo=true, index=true) var guild: Guild,
+    @DatabaseField(foreign = true, canBeNull = false) var guild: Guild,
     @DatabaseField(canBeNull = false, id = true) var messageId: Long,
     @DatabaseField(canBeNull = false) var channelId: Long,
-    @DatabaseField(canBeNull = false, uniqueCombo=true, dataType = DataType.LONG_STRING) var messageLink: String
+    @DatabaseField(canBeNull = false, dataType = DataType.LONG_STRING) var messageLink: String
 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added “Student Scoop” integration: automatically fetches and posts scoop images hourly to a configurable channel per server.
  - New “setscoopchannel” command (message and slash) for server admins to set or clear the target channel.
  - Posts include rich embeds; avoids duplicate postings.

- Chores
  - Updated logging and HTTP/HTML libraries to latest versions to improve reliability and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->